### PR TITLE
Document ability to add multiple Examples or Scenarios sections

### DIFF
--- a/content/docs/gherkin/reference.md
+++ b/content/docs/gherkin/reference.md
@@ -415,7 +415,8 @@ Scenario Outline: eating
 
 ### Examples
 
-A `Scenario Outline` must contain an `Examples` (or `Scenarios`) section. Its steps are interpreted as a template
+A `Scenario Outline` must contain one or more `Examples` (or `Scenarios`) section(s). Its steps are interpreted as a 
+template
 which is never directly run. Instead, the `Scenario Outline` is run *once for each row* in
 the `Examples` section beneath it (not counting the first header row).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Describe the ability to have multiple `Examples` or `Scenarios` sections

# Motivation & context

No description provided for support of multiple `Examples` or `Scenarios` sections

## Type of change

- Documentation

## Update required of cucumber.io/docs
Done

# Checklist:
- [x] I have updated the documentation accordingly.
